### PR TITLE
修复：使用bitmapdata.generateTexture创建Texture时，图像不能及时显示

### DIFF
--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -586,9 +586,14 @@ Phaser.BitmapData.prototype = {
 
         if (!callback)
         {
+            image.width = this.width;
+            image.height = this.height;
+            
             var obj = cache.addImage(key, '', image);
+            
+            obj.base.hasLoaded = true;
 
-            return new PIXI.Texture(obj.base);
+            return new PIXI.Texture(obj.base, new PIXI.Rectangle(0, 0, this.width, this.height));
         }
 
         return null;


### PR DESCRIPTION
因为设置image.src会有一个load过程，在onloaded之前width和height均为0，会导致后面cache.addImage时尺寸为0，图像不能即时显示（尽管图像已经在内存中完成绘制），所以这里先强制设置宽高再执行cach.addImage；
同样，强制设置baseTexture.hasLoaded，使后面创建的Textute按第二个参数更新frame（因为在Texture内部会先检测是否loaded，如果不设置hasLoaded，即使传了frame参数也不会即时显示）
然后，在后面new Texture时，增加第二个参数的rectangle尺寸生成图像。
